### PR TITLE
Fix Indicator not drawing on some devices

### DIFF
--- a/library/src/main/java/com/nshmura/recyclertablayout/RecyclerTabLayout.java
+++ b/library/src/main/java/com/nshmura/recyclertablayout/RecyclerTabLayout.java
@@ -77,6 +77,7 @@ public class RecyclerTabLayout extends RecyclerView {
 
     public RecyclerTabLayout(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        setWillNotDraw(false);
 
         mIndicatorPaint = new Paint();
         mLinearLayoutManager = new LinearLayoutManager(getContext());


### PR DESCRIPTION
On an HTC Desire X running Android 4.1 the indicator is not drawn unless you call setWillNotDraw(false)