### PR TITLE
handle NO_POSITION when clicked

### DIFF
--- a/library/src/main/java/com/nshmura/recyclertablayout/RecyclerTabLayout.java
+++ b/library/src/main/java/com/nshmura/recyclertablayout/RecyclerTabLayout.java
@@ -554,7 +554,10 @@ public class RecyclerTabLayout extends RecyclerView {
                 itemView.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        getViewPager().setCurrentItem(getAdapterPosition(), true);
+                        int pos = getAdapterPosition();
+                        if (pos != NO_POSITION) {
+                            getViewPager().setCurrentItem(pos, true);
+                        }
                     }
                 });
             }


### PR DESCRIPTION
`getAdapterPosition()` may return `NO_POSITION` which will cause scrolling to position 0

see: http://developer.android.com/reference/android/support/v7/widget/RecyclerView.ViewHolder.html#getAdapterPosition%28%29