### PR TITLE
Stop scrolling before scrolling to tab

### DIFF
--- a/library/src/main/java/com/nshmura/recyclertablayout/RecyclerTabLayout.java
+++ b/library/src/main/java/com/nshmura/recyclertablayout/RecyclerTabLayout.java
@@ -293,6 +293,7 @@ public class RecyclerTabLayout extends RecyclerView {
             mRequestScrollToTab = true;
         }
 
+        stopScroll();
         mLinearLayoutManager.scrollToPositionWithOffset(position, scrollOffset);
 
         if (mIndicatorHeight > 0) {


### PR DESCRIPTION
## Problem
I think RecyclerTabLayout should stop scrolling when swiping ViewPager to next page, but it doesn't stop.

## Solution
call `stopScroll()` in `RecyclerTabLayout#scrollToTab(int position, float positionOffset, boolean fitIndicator)`

## Result
### Before
<img src="https://raw.githubusercontent.com/takuaraki/RecyclerTabLayout/images/stopScroll/before.gif">

### After
<img src="https://raw.githubusercontent.com/takuaraki/RecyclerTabLayout/images/stopScroll/after.gif">