### PR TITLE
Fix "Invalid indicator position"

### DIFF
--- a/library/src/main/java/com/nshmura/recyclertablayout/RecyclerTabLayout.java
+++ b/library/src/main/java/com/nshmura/recyclertablayout/RecyclerTabLayout.java
@@ -312,10 +312,11 @@ public class RecyclerTabLayout extends RecyclerView {
             return;
         }
         int indicatorPosition = -1;
-        if (dx > 0 && positionOffset >= mPositionThreshold - POSITION_THRESHOLD_ALLOWABLE) {
+        boolean isNewPosition = position != mOldPosition;
+        if ((dx > 0 || isNewPosition) && positionOffset >= mPositionThreshold - POSITION_THRESHOLD_ALLOWABLE) {
             indicatorPosition = position + 1;
 
-        } else if (dx < 0 && positionOffset <= 1 - mPositionThreshold + POSITION_THRESHOLD_ALLOWABLE) {
+        } else if ((dx < 0 || isNewPosition) && positionOffset <= 1 - mPositionThreshold + POSITION_THRESHOLD_ALLOWABLE) {
             indicatorPosition = position;
         }
         if (indicatorPosition >= 0 && indicatorPosition != mAdapter.getCurrentIndicatorPosition()) {


### PR DESCRIPTION
Sometimes when I change position of ViewPager I see that current tab at RecyclerTabLayout stay the same. I've figure out after some debugging where is problem.
See at method updateCurrentIndicatorPosition. This method don't change adapter's indicatorPosition if dx is 0. So RecyclerTabLayout's position and ViewPager's position do not match. My commit fix this issue. I am comparing not only dx but position to be know we need call notifyDataSetChanged.

Closes https://github.com/nshmura/RecyclerTabLayout/issues/49